### PR TITLE
Remove the sample rate correction for Plaits

### DIFF
--- a/plaits/dsp/dsp.h
+++ b/plaits/dsp/dsp.h
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// 
+//
 // See http://creativecommons.org/licenses/MIT/ for more information.
 //
 // -----------------------------------------------------------------------------
@@ -32,7 +32,7 @@
 #include "stmlib/stmlib.h"
 
 namespace plaits {
-  
+
 static const float kSampleRate = 48000.0f;
 
 // There is no proper PLL for I2S, only a divider on the system clock to derive
@@ -44,8 +44,11 @@ static const float kSampleRate = 48000.0f;
 //
 // That's only 4.6 cts of error, but we care!
 
-static const float kCorrectedSampleRate = 47872.34f;
-const float a0 = (440.0f / 8.0f) / kCorrectedSampleRate;
+// static const float kCorrectedSampleRate = 47872.34f;
+// const float a0 = (440.0f / 8.0f) / kCorrectedSampleRate;
+
+// In Surge, we don't need the above correction since we're running Plaits at straight 48k!
+const float a0 = (440.0f / 8.0f);
 
 const size_t kMaxBlockSize = 24;
 const size_t kBlockSize = 12;


### PR DESCRIPTION
Since we run Plaits at straight 48k in Surge, this is not necessary.