### PR TITLE
Do not read past lut_window when the grain envelope is at its peak

### DIFF
--- a/clouds/dsp/grain.h
+++ b/clouds/dsp/grain.h
@@ -99,7 +99,17 @@ class Grain {
       if (use_lut_for_envelope) {
         if (quality == GRAIN_QUALITY_HIGH) {
           float window = 0.0f;
-          window = stmlib::Interpolate(lut_window, gain, 4096.0f);
+          // gain is exactly 1.0f when the envelope phase is exactly 1.0f, since
+          // 2.0f - 1.0f is 1.0f. Interpolate then indexes lut_window[4096] and
+          // lut_window[4097], and the table holds LUT_WINDOW_SIZE (4097) entries,
+          // so the second read is one float past the end of the table. It is
+          // scaled by a fractional part of exactly zero, so the interpolated
+          // result is the last table entry either way - unless the bytes that
+          // follow the table happen to read back as a NaN, which would carry
+          // into the envelope.
+          window = gain >= 1.0f
+              ? lut_window[LUT_WINDOW_SIZE - 1]
+              : stmlib::Interpolate(lut_window, gain, 4096.0f);
           gain += smoothness * (window - gain);
         }
       } else {

--- a/clouds/dsp/grain.h
+++ b/clouds/dsp/grain.h
@@ -99,14 +99,7 @@ class Grain {
       if (use_lut_for_envelope) {
         if (quality == GRAIN_QUALITY_HIGH) {
           float window = 0.0f;
-          // gain is exactly 1.0f when the envelope phase is exactly 1.0f, since
-          // 2.0f - 1.0f is 1.0f. Interpolate then indexes lut_window[4096] and
-          // lut_window[4097], and the table holds LUT_WINDOW_SIZE (4097) entries,
-          // so the second read is one float past the end of the table. It is
-          // scaled by a fractional part of exactly zero, so the interpolated
-          // result is the last table entry either way - unless the bytes that
-          // follow the table happen to read back as a NaN, which would carry
-          // into the envelope.
+          // dont read off the end of table for phase 1
           window = gain >= 1.0f
               ? lut_window[LUT_WINDOW_SIZE - 1]
               : stmlib::Interpolate(lut_window, gain, 4096.0f);


### PR DESCRIPTION
Based on and targeting `surge`, since that is the branch Surge XT's submodule tracks.

### What

`Grain::RenderEnvelope` folds the envelope phase into a gain with

```cpp
gain = gain >= 1.0f ? 2.0f - gain : gain;
```

`2.0f - 1.0f` is `1.0f`, so a phase of exactly 1.0f leaves `gain` at exactly 1.0f rather than folding it below. `stmlib::Interpolate(lut_window, 1.0f, 4096.0f)` then computes an integral index of 4096 and reads **both** `lut_window[4096]` and `lut_window[4097]`. `LUT_WINDOW_SIZE` is 4097, so valid indices stop at 4096 and that second read is one float past the end of the global.

Caught by ASan running Surge XT's `Nimbus at High Sample Rate` test:

```
==77031==ERROR: AddressSanitizer: global-buffer-overflow
READ of size 4 at 0x000105024824 thread T0
    #0 stmlib::Interpolate(float const*, float, float) dsp.h:47
    #1 clouds::Grain::RenderEnvelope<true, GRAIN_QUALITY_HIGH>(float*, unsigned long) grain.h:102
    #2 clouds::Grain::OverlapAdd<2, GRAIN_QUALITY_HIGH, RESOLUTION_16_BIT>(...) grain.h:143
    #3 clouds::GranularSamplePlayer::Play<RESOLUTION_16_BIT>(...) granular_sample_player.h:129
    #4 clouds::GranularProcessor::ProcessGranular(...) granular_processor.cc:112
    #5 clouds::GranularProcessor::Process(...) granular_processor.cc:211

0x000105024824 is located 0 bytes after global variable 'clouds::lut_window'
defined in 'clouds/resources.cc' (0x000105020820) of size 16388
```

This is on the audio thread — it happens for any grain at `GRAIN_QUALITY_HIGH` whose envelope phase lands exactly on 1.0f.

### Is it actually harmful?

Mostly not, which is presumably why it has gone unnoticed. `Interpolate` returns `a + (b - a) * index_fractional`, and at the endpoint `index_fractional` is exactly 0.0f, so the out-of-bounds sample is multiplied away and the result is `lut_window[4096]` regardless.

The exception is the one that matters: if the bytes immediately after the table read back as a NaN, then `(b - a) * 0.0f` is NaN rather than zero, and that NaN goes into the grain envelope. What sits after a global is a link-order detail, so this stays quiet until some build lays things out differently.

### The change

Return the last table entry directly at the endpoint. Since the current result is already `lut_window[4096]`, this is bit identical for every input and simply drops the read.

`gain` cannot exceed 1.0f here — `RenderEnvelope` breaks out of its loop once `phase >= 2.0f`, so `gain` stays within [0, 1] — so the endpoint is the only case needing a guard.

### Verification

- `Nimbus at High Sample Rate` goes from aborting under ASan after 2 assertions to passing all 16.
- Surge XT's full `[fx]` suite is unchanged at **3202892 assertions across 9 test cases**, in both a normal build and an ASan/UBSan build, so no audio output moved.
- `lut_window` is interpolated from exactly one call site, so there is no other path to the same endpoint.

Happy to reshape this if you would rather keep the vendored tree closer to upstream and fix it on the Surge side instead.

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
